### PR TITLE
No longer raise a RuntimeError if an input file was not formatted wel…

### DIFF
--- a/bin/gherkin_format
+++ b/bin/gherkin_format
@@ -36,15 +36,15 @@ if options.key? :template
   exit 0
 end
 
-exitCode = 0
+exit_code = 0
 
 ARGV.each do |file|
   begin
     formatter.format file, options
   rescue StandardError => e
     puts e.message
-    exitCode = 1
+    exit_code = 1
   end
 end
 
-exit exitCode
+exit exit_code

--- a/bin/gherkin_format
+++ b/bin/gherkin_format
@@ -36,6 +36,15 @@ if options.key? :template
   exit 0
 end
 
+exitCode = 0
+
 ARGV.each do |file|
-  formatter.format file, options
+  begin
+    formatter.format file, options
+  rescue StandardError => e
+    puts e.message
+    exitCode = 1
+  end
 end
+
+exit exitCode

--- a/lib/gherkin_format.rb
+++ b/lib/gherkin_format.rb
@@ -24,17 +24,10 @@ class GherkinFormat
 
     if options.key? :replace
       File.write(file, output)
-      puts "File #{file} was not formatted well. Fixed it for you!"
+      raise "File #{file} was not formatted well. Fixed it!"
     else
-      puts "File #{file} is not formatted well. Re-run with --replace"
+      raise "File #{file} is not formatted well. To fix, re-run with --replace"
     end
-
-    fail_with 'Terminating. Some files may not have been checked.'
-  end
-
-  def fail_with(message)
-    puts message
-    exit 1
   end
 
   def render(template, files)

--- a/lib/gherkin_format.rb
+++ b/lib/gherkin_format.rb
@@ -26,10 +26,14 @@ class GherkinFormat
       File.write(file, output)
       puts "File #{file} was not formatted well. Fixed it for you!"
     else
-      puts "File #{file} is not formatted well. Please fix or re-run me with --replace switch."
+      puts "File #{file} is not formatted well. Re-run with --replace"
     end
 
-    puts "Terminating. Some files may not have been checked yet, please consider a re-run."
+    fail_with "Terminating. Some files may not have been checked."
+  end
+
+  def fail_with(message)
+    puts message
     exit 1
   end
 

--- a/lib/gherkin_format.rb
+++ b/lib/gherkin_format.rb
@@ -26,8 +26,11 @@ class GherkinFormat
       File.write(file, output)
       puts "File #{file} was not formatted well. Fixed it for you!"
     else
-      puts "File #{file} is not formatted well."
+      puts "File #{file} is not formatted well. Please fix or re-run me with --replace switch."
     end
+
+    puts "Terminating. Some files may not have been checked yet, please consider a re-run."
+    exit 1
   end
 
   def render(template, files)

--- a/lib/gherkin_format.rb
+++ b/lib/gherkin_format.rb
@@ -29,7 +29,7 @@ class GherkinFormat
       puts "File #{file} is not formatted well. Re-run with --replace"
     end
 
-    fail_with "Terminating. Some files may not have been checked."
+    fail_with 'Terminating. Some files may not have been checked.'
   end
 
   def fail_with(message)

--- a/lib/gherkin_format.rb
+++ b/lib/gherkin_format.rb
@@ -22,12 +22,8 @@ class GherkinFormat
     output = format_string input, file
     return if input == output
 
-    if options.key? :replace
-      File.write(file, output)
-      raise "File #{file} was not formatted well. Fixed it!"
-    else
-      raise "File #{file} is not formatted well. To fix, re-run with --replace"
-    end
+    File.write(file, output) if options.key? :replace
+    raise "File #{file} was not formatted well."
   end
 
   def render(template, files)

--- a/lib/gherkin_format.rb
+++ b/lib/gherkin_format.rb
@@ -22,10 +22,12 @@ class GherkinFormat
     output = format_string input, file
     return if input == output
 
-    File.write(file, output) if options.key? :replace
-
-    puts "File #{file} is not formatted well."
-    raise "File #{file} is not formatted well."
+    if options.key? :replace
+      File.write(file, output)
+      puts "File #{file} was not formatted well. Fixed it for you!"
+    else
+      puts "File #{file} is not formatted well."
+    end
   end
 
   def render(template, files)


### PR DESCRIPTION
…l. It is quite normal to accept such input. Also log 'Fixed it for you' in case a file has been fixed by gherkin_format.